### PR TITLE
update to ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - name: Install deps
         run: sudo apt-get install -y libpq-dev

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
-ruby '~>2.6'
+ruby '2.7.7'
 
-gem 'rails', '~>4.2.11.1'
+gem 'rails', '~>4.2.11'
+gem 'bigdecimal', '1.3.5' # to make ruby 2.7 work with rails 4.2
 gem 'oauth2'
 gem 'virtus'
 gem 'liquid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.2.11.1)
-      actionpack (= 4.2.11.1)
-      actionview (= 4.2.11.1)
-      activejob (= 4.2.11.1)
+    actionmailer (4.2.11.3)
+      actionpack (= 4.2.11.3)
+      actionview (= 4.2.11.3)
+      activejob (= 4.2.11.3)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.11.1)
-      actionview (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
+    actionpack (4.2.11.3)
+      actionview (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.11.1)
-      activesupport (= 4.2.11.1)
+    actionview (4.2.11.3)
+      activesupport (= 4.2.11.3)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (4.2.11.1)
-      activesupport (= 4.2.11.1)
+    activejob (4.2.11.3)
+      activesupport (= 4.2.11.3)
       globalid (>= 0.3.0)
-    activemodel (4.2.11.1)
-      activesupport (= 4.2.11.1)
+    activemodel (4.2.11.3)
+      activesupport (= 4.2.11.3)
       builder (~> 3.1)
-    activerecord (4.2.11.1)
-      activemodel (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
+    activerecord (4.2.11.3)
+      activemodel (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
       arel (~> 6.0)
-    activesupport (4.2.11.1)
+    activesupport (4.2.11.3)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -43,6 +43,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    bigdecimal (1.3.5)
     builder (3.2.4)
     capybara (2.17.0)
       addressable
@@ -58,10 +59,11 @@ GEM
       virtus (~> 1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    date (3.3.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
@@ -74,7 +76,7 @@ GEM
     execjs (2.7.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -106,17 +108,29 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    mini_mime (1.0.2)
+    mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.13.0)
+    minitest (5.16.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
@@ -141,22 +155,22 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (1.6.13)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.11.1)
-      actionmailer (= 4.2.11.1)
-      actionpack (= 4.2.11.1)
-      actionview (= 4.2.11.1)
-      activejob (= 4.2.11.1)
-      activemodel (= 4.2.11.1)
-      activerecord (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
+    rails (4.2.11.3)
+      actionmailer (= 4.2.11.3)
+      actionpack (= 4.2.11.3)
+      actionview (= 4.2.11.3)
+      activejob (= 4.2.11.3)
+      activemodel (= 4.2.11.3)
+      activerecord (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.11.1)
+      railties (= 4.2.11.3)
       sprockets-rails
-    rails-deprecated_sanitizer (1.0.3)
+    rails-deprecated_sanitizer (1.0.4)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.9)
       activesupport (>= 4.2.0, < 5.0)
@@ -169,12 +183,12 @@ GEM
       rails_stdout_logging
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.5)
-    railties (4.2.11.1)
-      actionpack (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
+    railties (4.2.11.3)
+      actionpack (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (13.0.1)
+    rake (13.0.6)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -226,16 +240,17 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     test-unit (3.5.3)
       power_assert
-    thor (1.0.1)
+    thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.5)
+    timeout (0.3.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     uglifier (4.1.5)
@@ -259,6 +274,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (= 1.3.5)
   capybara
   cobot_client
   email_validator
@@ -273,7 +289,7 @@ DEPENDENCIES
   omniauth_cobot (~> 0.0.3)
   pg (~> 0.21)
   puma
-  rails (~> 4.2.11.1)
+  rails (~> 4.2.11)
   rails_12factor
   rspec-rails
   sass-rails
@@ -287,7 +303,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.3p205
+   ruby 2.7.7p221
 
 BUNDLED WITH
    1.16.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,25 +21,3 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 end
-
-
-# a workaround to avoid MonitorMixin double-initialize error
-# https://github.com/rails/rails/issues/34790#issuecomment-681034561
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
-  if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
-    class ActionController::TestResponse < ActionDispatch::TestResponse
-      def recycle!
-        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-          @mon_data = nil
-          @mon_data_owner_object_id = nil
-        else
-          @mon_mutex = nil
-          @mon_mutex_owner_object_id = nil
-        end
-        initialize
-      end
-    end
-  else
-    $stderr.puts "Monkeypatch for ActionController::TestResponse is no longer needed"
-  end
-end

--- a/spec/support/ruby_2_7_support_helpers.rb
+++ b/spec/support/ruby_2_7_support_helpers.rb
@@ -1,0 +1,20 @@
+# a workaround to avoid MonitorMixin double-initialize error
+# https://github.com/rails/rails/issues/34790#issuecomment-681034561
+if RUBY_VERSION >= '2.6.0'
+  if Rails.version < '5'
+    class ActionController::TestResponse < ActionDispatch::TestResponse
+      def recycle!
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+          @mon_data = nil
+          @mon_data_owner_object_id = nil
+        else
+          @mon_mutex = nil
+          @mon_mutex_owner_object_id = nil
+        end
+        initialize
+      end
+    end
+  else
+    puts "Monkeypatch for ActionController::TestResponse no longer needed"
+  end
+end


### PR DESCRIPTION
- update to gem dependencies
- moved monkey path for rails 4 support to extra file

Update is needed to move away from heroku18 stack, which is EOL